### PR TITLE
Adds edit button to showcase and makes form render conditionally

### DIFF
--- a/client/src/components/UserPage.jsx
+++ b/client/src/components/UserPage.jsx
@@ -27,6 +27,10 @@ function UserPage() {
   };
 
   useEffect(() => {
+    setInterestIsVisible(false);
+    setSkillsIsVisible(false);
+    setShowcaseIsVisible(false);
+
     if (id) {
       getUserById().then((data) => {
         setUserProfile(data);
@@ -96,7 +100,7 @@ function UserPage() {
               alt=""
             />
           </button>
-          {showcaseIsVisible && <UserShowcase />}
+          {showcaseIsVisible && <UserShowcase userProfile={userProfile} />}
         </div>
         <UserReviews />
       </div>

--- a/client/src/components/UserShowcase.jsx
+++ b/client/src/components/UserShowcase.jsx
@@ -1,51 +1,68 @@
-import "../styles/showcase.css"
-import { useState, useContext } from "react";
-import supabase from "../../config/config_file";
+import "../styles/showcase.css";
+import { useState } from "react";
+import { useContext } from "react";
 import { UserContext } from "../contexts/UserContext";
+import supabase from "../../config/config_file";
 
-function UserShowcase() {
-  const { user } = useContext(UserContext)
-  const [inputField, setInputField] = useState('')
-  
-  
+function UserShowcase({ userProfile }) {
+  const { user } = useContext(UserContext);
+  const [newShowcase, setNewShowcase] = useState("");
+  const [currentShowcase, setCurrentShowcase] = useState(userProfile.showcase);
+  const [isEditDisabled, setIsEditDisabled] = useState(true);
+  console.log(user.user_id);
+
   const handleOnSubmit = async (e) => {
-    e.preventDefault()
+    e.preventDefault();
     try {
       const { data, error } = await supabase
         .from("Users")
-        .update({ showcase: inputField })
-        .eq('user_id', user.user_id)
-        
+        .update({ showcase: newShowcase })
+        .eq("user_id", userProfile.user_id);
     } catch (error) {
-      console.log(error)
+      console.log(error);
     }
-
-    alert('Showcase updated')
-  }
+    setIsEditDisabled(true);
+    setCurrentShowcase(newShowcase);
+  };
 
   const handleChange = (e) => {
-    setInputField(e.target.value)
-    
-  }
-  
-  return ( 
+    setNewShowcase(e.target.value);
+  };
+
+  return (
     <div className="showcase-container">
-     
-      <form onSubmit={handleOnSubmit}>
-        <textarea
-          className="textarea"
-          name="showcaseContent"
-          placeholder="Write your showcase here...."
-          type="text"
-          onChange={handleChange}
-          defaultValue={user.showcase}
-        />
-        <button className="showcaseSubmit" type="submit">✅</button>
-        </form>
-       
-      
+      <section>{currentShowcase}</section>
+      {userProfile.user_id === user.user_id ? (
+        <>
+          <button
+            onClick={() => {
+              if (isEditDisabled) {
+                setIsEditDisabled(false);
+              } else {
+                setIsEditDisabled(true);
+              }
+            }}
+          >
+            Edit your showcase
+          </button>
+          <form onSubmit={handleOnSubmit}>
+            <textarea
+              disabled={isEditDisabled}
+              className="textarea"
+              name="showcaseContent"
+              placeholder="Write your showcase here...."
+              type="text"
+              onChange={handleChange}
+              defaultValue={currentShowcase}
+            />
+            <button className="showcaseSubmit" type="submit">
+              Submit change
+            </button>
+          </form>{" "}
+        </>
+      ) : null}
     </div>
-  )
+  );
 }
 
 export default UserShowcase;


### PR DESCRIPTION
In the showcase:
- Adds edit button (on click it enables or disables the text area of the form)
- The edit button and the form are conditionally rendered and only visible if the userprofile belongs to the logged user.

In the userpage: 
- Sets InterestIsVisible, skillsIsVisible, and showcaseIsVisible to false inside useEffect to ensure that tabs are closed whenever the id changes (i.e. going from another user's profile to your own).