### PR TITLE
User dropdown connection fix

### DIFF
--- a/client/src/components/UserDropdown.jsx
+++ b/client/src/components/UserDropdown.jsx
@@ -36,7 +36,7 @@ function UserDropdown() {
         { chat_id: chatId, user_id: id },
         { chat_id: chatId, user_id: userIdToConnect.user_id },
       ]);
-      navigate(`/chat/${chatId}`);
+      navigate(`/connections`);
     } else {
       alert("Username doesn't exist!");
     }


### PR DESCRIPTION
Switched navigation to connections page after creating a chat. This doesn't cause an error as opposed to try navigating to the newly created chat